### PR TITLE
Fix failing unit test

### DIFF
--- a/test-res/products.mondrian.xml
+++ b/test-res/products.mondrian.xml
@@ -6,7 +6,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="BUYPRICE" column="BUYPRICE" uniqueMembers="false">
+      <Level name="BUYPRICE" column="BUYPRICE" type="Numeric" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -17,7 +17,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="MSRP" column="MSRP" uniqueMembers="false">
+      <Level name="MSRP" column="MSRP" type="Numeric" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -28,7 +28,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTCODE" column="PRODUCTCODE" uniqueMembers="false">
+      <Level name="PRODUCTCODE" column="PRODUCTCODE" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -39,7 +39,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTDESCRIPTION" column="PRODUCTDESCRIPTION" uniqueMembers="false">
+      <Level name="PRODUCTDESCRIPTION" column="PRODUCTDESCRIPTION" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -50,7 +50,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTLINE" column="PRODUCTLINE" uniqueMembers="false">
+      <Level name="PRODUCTLINE" column="PRODUCTLINE" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -61,7 +61,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTNAME" column="PRODUCTNAME" uniqueMembers="false">
+      <Level name="PRODUCTNAME" column="PRODUCTNAME" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -72,7 +72,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTSCALE" column="PRODUCTSCALE" uniqueMembers="false">
+      <Level name="PRODUCTSCALE" column="PRODUCTSCALE" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -83,7 +83,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTVENDOR" column="PRODUCTVENDOR" uniqueMembers="false">
+      <Level name="PRODUCTVENDOR" column="PRODUCTVENDOR" type="String" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -94,7 +94,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="QUANTITYINSTOCK" column="QUANTITYINSTOCK" uniqueMembers="false">
+      <Level name="QUANTITYINSTOCK" column="QUANTITYINSTOCK" type="Numeric" uniqueMembers="false">
       </Level>
     </Hierarchy>
   </Dimension>

--- a/test-src/org/pentaho/agilebi/modeler/ModelerWorkspaceTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/ModelerWorkspaceTest.java
@@ -135,7 +135,11 @@ public class ModelerWorkspaceTest extends AbstractModelerTest{
     mondrianSchema = mondrianSchema.replaceAll("\r", "");
     mondrianXmlBeforeUpConvert = mondrianXmlBeforeUpConvert.replaceAll("\r", "");
 
-    assertTrue(StringUtils.deleteWhitespace(mondrianXmlBeforeUpConvert).equals(StringUtils.deleteWhitespace(mondrianSchema)));
+    String expected = StringUtils.deleteWhitespace(mondrianSchema);
+    String actual = StringUtils.deleteWhitespace(mondrianXmlBeforeUpConvert);
+
+//    assertTrue(StringUtils.deleteWhitespace(mondrianXmlBeforeUpConvert).equals(StringUtils.deleteWhitespace(mondrianSchema)));
+    assertEquals(actual, expected);
 
   }
 


### PR DESCRIPTION
Fix failing unit test, MondrianModelExport now adds type to the level definition, this was not accounted for in this unit test when that was added. The expected result is now in sync with that new feature.
