### PR TITLE
fixes for BISERVER-7185 & BISERVER-7189

### DIFF
--- a/src/org/pentaho/agilebi/modeler/ModelerConversionUtil.java
+++ b/src/org/pentaho/agilebi/modeler/ModelerConversionUtil.java
@@ -6,7 +6,9 @@ import org.pentaho.metadata.model.concept.types.AggregationType;
 import org.pentaho.metadata.model.concept.types.DataType;
 import org.pentaho.metadata.model.concept.types.LocalizedString;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * User: rfellows
@@ -244,7 +246,7 @@ public class ModelerConversionUtil {
           }
         }
         
-        String colId = "LC_" + table.getPhysicalTable().getName(locale) + "_"
+        String colId = "LC_" + ModelerWorkspace.toId(table.getPhysicalTable().getName(locale)) + "_"
             + col.getPhysicalColumn().getId() + BaseModelerWorkspaceHelper.OLAP_SUFFIX;
 
         colId = BaseModelerWorkspaceHelper.uniquify(colId, olapColumns);

--- a/src/org/pentaho/agilebi/modeler/ModelerWorkspace.java
+++ b/src/org/pentaho/agilebi/modeler/ModelerWorkspace.java
@@ -1035,7 +1035,9 @@ public class ModelerWorkspace extends XulEventSourceAdapter implements Serializa
         lCol.setAggregationType(field.getPhysicalColumn().getAggregationType());
       }
       lCol.setName(new LocalizedString(locale, field.getPhysicalColumn().getName(locale)));
-      String colId = "LC_" + lTab.getPhysicalTable().getName(locale) + "_" + field.getPhysicalColumn().getId();
+      String colId = "LC_" + toId(lTab.getPhysicalTable().getName(locale)) + "_" + field.getPhysicalColumn().getId();
+
+//      lCol.setDescription(new LocalizedString(locale, field.getPhysicalColumn().getName(locale)));
 
       if (perspective == ModelerPerspective.ANALYSIS) {
         colId += BaseModelerWorkspaceHelper.OLAP_SUFFIX;
@@ -1098,4 +1100,24 @@ public class ModelerWorkspace extends XulEventSourceAdapter implements Serializa
         return this.getDomain().getLogicalModels().get(0);
     }
   }
+
+
+  public static final String toId(String name) {
+    if (name == null) {
+      return name;
+    }
+    name = name.replaceAll("[ .,:(){}\\[\\]]", "_"); //$NON-NLS-1$ //$NON-NLS-2$
+    name = name.replaceAll("[\"]", ""); //$NON-NLS-1$ //$NON-NLS-2$
+    name = name.replaceAll("_+", "_"); //$NON-NLS-1$ //$NON-NLS-2$
+    return name;
+  }
+
+  public static final String removeQuotes(String name) {
+    if (name == null) {
+      return name;
+    }
+    name = name.replaceAll("[\"]", ""); //$NON-NLS-1$ //$NON-NLS-2$
+    return name;
+  }
+
 }

--- a/test-src/org/pentaho/agilebi/modeler/CategoryTreeHelperTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/CategoryTreeHelperTest.java
@@ -143,7 +143,7 @@ public class CategoryTreeHelperTest {
     assertTrue(one != two);
 
     // make sure they got unique column id's
-    String expectedColId = "LC_" + physicalColumn.getPhysicalTable().getName("en-US") + "_" + physicalColumn.getName("en-US");
+    String expectedColId = "LC_" + ModelerWorkspace.toId(physicalColumn.getPhysicalTable().getName("en-US")) + "_" + physicalColumn.getName("en-US");
     assertEquals(expectedColId, one.getLogicalColumn().getId());
     assertEquals(expectedColId + "_2", two.getLogicalColumn().getId());
 


### PR DESCRIPTION
BISERVER-7185 -Datasource wizard does not show correct foodmart tables/fields when using the Oracle driver.
BISERVER-7189 -Metadata columns contains invalid characters (space). String needs to be sanitized.
