### PR TITLE
Added Time Level Format to ui to edit AnalyzerDateFormat annotations.

### DIFF
--- a/src/org/pentaho/agilebi/modeler/BaseModelerWorkspaceHelper.java
+++ b/src/org/pentaho/agilebi/modeler/BaseModelerWorkspaceHelper.java
@@ -123,7 +123,8 @@ public abstract class BaseModelerWorkspaceHelper implements IModelerWorkspaceHel
           OlapHierarchyLevel level = new OlapHierarchyLevel(hierarchy);
           level.setName(lvl.getName());
           if (isTimeDimension) {
-            level.setLevelType(((TimeRole)lvl.getDataRole()).getMondrianAttributeValue());
+            TimeRole timeRole = (TimeRole) lvl.getDataRole();
+            if (timeRole != null) level.setLevelType(timeRole.getMondrianAttributeValue());
           }
           LogicalColumn lCol = lvl.getLogicalColumn();
 

--- a/src/org/pentaho/agilebi/modeler/nodes/AbstractMetaDataModelNode.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/AbstractMetaDataModelNode.java
@@ -159,7 +159,8 @@ public abstract class AbstractMetaDataModelNode<T extends AbstractMetaDataModelN
         continue;
       }
       valid &= anno.isValid(this);
-      validationMessages.addAll(anno.getValidationMessages(this));
+      List<String> messages = anno.getValidationMessages(this);
+      if (messages != null) validationMessages.addAll(messages);
     }
 
     if (suppressEvents == false) {

--- a/src/org/pentaho/agilebi/modeler/nodes/BaseColumnBackedMetaData.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/BaseColumnBackedMetaData.java
@@ -3,6 +3,10 @@ package org.pentaho.agilebi.modeler.nodes;
 import org.pentaho.agilebi.modeler.ColumnBackedNode;
 import org.pentaho.agilebi.modeler.ModelerException;
 import org.pentaho.agilebi.modeler.ModelerMessagesHolder;
+import org.pentaho.agilebi.modeler.nodes.annotations.AnalyzerDateFormatAnnotation;
+import org.pentaho.agilebi.modeler.nodes.annotations.IMemberAnnotation;
+import org.pentaho.agilebi.modeler.nodes.annotations.IAnalyzerDateFormatAnnotation;
+import org.pentaho.agilebi.modeler.nodes.annotations.AnalyzerDateFormatAnnotationFactory;
 import org.pentaho.agilebi.modeler.propforms.LevelsPropertiesForm;
 import org.pentaho.agilebi.modeler.propforms.ModelerNodePropertiesForm;
 import org.pentaho.metadata.model.IPhysicalTable;
@@ -11,6 +15,8 @@ import org.pentaho.metadata.model.LogicalTable;
 import org.pentaho.ui.xul.stereotype.Bindable;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created: 3/18/11
@@ -25,9 +31,10 @@ public class BaseColumnBackedMetaData<T extends AbstractMetaDataModelNode> exten
   protected transient LogicalColumn logicalOrdinalColumn;
   protected transient LogicalColumn logicalCaptionColumn;
   protected boolean uniqueMembers = false;
+  protected String timeLevelFormat;
   private static final String IMAGE = "images/sm_level_icon.png";
   private String description = "";
-
+  
   public BaseColumnBackedMetaData(){
 
   }
@@ -124,6 +131,7 @@ public class BaseColumnBackedMetaData<T extends AbstractMetaDataModelNode> exten
     return logicalCaptionColumn;
   }
 
+  @Bindable
   public void setLogicalCaptionColumn( LogicalColumn col ) {
     LogicalColumn prevVal = this.logicalCaptionColumn;
     this.logicalCaptionColumn = col;
@@ -131,6 +139,7 @@ public class BaseColumnBackedMetaData<T extends AbstractMetaDataModelNode> exten
     firePropertyChange("logicalCaptionColumn", prevVal, col);
   }
 
+  @Bindable
   public void setUniqueMembers( boolean uniqueMembers ) {
     boolean oldUniqueMembers = this.uniqueMembers;
     if (oldUniqueMembers == uniqueMembers) return;
@@ -138,8 +147,105 @@ public class BaseColumnBackedMetaData<T extends AbstractMetaDataModelNode> exten
     firePropertyChange("uniqueMembers", oldUniqueMembers, uniqueMembers);
   }
 
+  @Bindable
   public boolean isUniqueMembers() {
     return uniqueMembers;
+  }
+
+  /**
+   * Derive the AnalyzerDateFormatAnnotation value by looking at parent levels.
+   **/
+  public String getFullTimeLevelFormat() {
+    String format = null;
+    HierarchyMetaData hierarchyMetaData = (HierarchyMetaData)getParent();
+    List<LevelMetaData> levels = hierarchyMetaData.getLevels();
+    for (LevelMetaData ancestorOrSelf : levels) {
+      format = (format == null ? "" : format + IAnalyzerDateFormatAnnotation.SEPARATOR) + 
+          AnalyzerDateFormatAnnotation.quoteTimeLevelFormat(ancestorOrSelf.getTimeLevelFormat())
+      ;
+      if (ancestorOrSelf == this) break;
+    }
+    return format;
+  }
+  
+  /*
+   *  Update AnalyzerDateFormatAnnotations of descendant levels.
+   **/
+  public void updateDescendantAnalyzerDateFormatAnnotations(){
+    HierarchyMetaData hierarchyMetaData = (HierarchyMetaData)getParent();
+    List<LevelMetaData> levels = hierarchyMetaData.getLevels();
+    String format = null, timeLevelFormat;
+    AnalyzerDateFormatAnnotation annotation;
+    Map<String, IMemberAnnotation> annotations;
+    String key = IAnalyzerDateFormatAnnotation.NAME;
+    boolean isDescendant = false;
+    for (LevelMetaData descendant : levels) {
+      timeLevelFormat = descendant.getTimeLevelFormat();
+      format = (format == null ? "" : format + IAnalyzerDateFormatAnnotation.SEPARATOR) + 
+          AnalyzerDateFormatAnnotation.quoteTimeLevelFormat(timeLevelFormat)
+      ;
+      if (!isDescendant) {
+        if (descendant == this) isDescendant = true;
+        continue;
+      }
+      annotations = descendant.annotations;
+      if (!annotations.containsKey(key)) continue;
+      annotation = (AnalyzerDateFormatAnnotation)annotations.get(key);
+      annotation.setValue(format);
+    }
+  }
+  
+  /**
+   * This is the format string that describes only this level's column values.
+   * This appears as the last part in AnalyzerDateFormatAnnotations
+   **/
+  @Bindable
+  public String getTimeLevelFormat() {
+    return timeLevelFormat;
+  }
+
+  /**
+   * This sets the format string that describes only this level's column values.
+   * This will automatically create a correct AnalyzerDateFormatAnnotation for this level
+   * and update the annotations for the levels below this level.
+   **/
+  @Bindable
+  public void setTimeLevelFormat(String timeLevelFormat) {
+    if ("".equals(timeLevelFormat)) timeLevelFormat = null;
+    String oldTimeLevelFormat = this.timeLevelFormat;
+    if (timeLevelFormat == null && oldTimeLevelFormat == null) return;
+    if (timeLevelFormat != null && oldTimeLevelFormat != null && timeLevelFormat.equals(oldTimeLevelFormat)) return;
+    this.timeLevelFormat = timeLevelFormat;
+    String key = IAnalyzerDateFormatAnnotation.NAME;
+    AnalyzerDateFormatAnnotation annotation = (AnalyzerDateFormatAnnotation)annotations.get(key);
+    if (annotation == null && timeLevelFormat == null) return;
+    if (annotation == null && timeLevelFormat != null) {
+      annotation = (AnalyzerDateFormatAnnotation)AnalyzerDateFormatAnnotationFactory.instance.create((LevelMetaData)this);
+      annotations.put(key, annotation);
+    }
+    else 
+    if (annotation != null && timeLevelFormat == null) {
+      annotations.remove(key);
+      annotation = null;
+    }
+    else {
+      String newAnalyzerDateFormatValue = getFullTimeLevelFormat();
+      if (annotation.getValue().equals(newAnalyzerDateFormatValue)) return;
+      annotation.setValue(newAnalyzerDateFormatValue);
+    }
+    updateDescendantAnalyzerDateFormatAnnotations();
+    firePropertyChange("timeLevelFormat", oldTimeLevelFormat, timeLevelFormat);
+    validateNode();
+  }
+  
+  /**
+   * This method is meant to be called only from the annotation's onAttach handler.
+   * onAttach is called right *before* the annotation is actually added to the annotations collection.
+   * This makes it very complicated (impossible?) to use update timeLevelFormat using the standard setter
+   * (because that setter has logic to update annotations accordingly)
+   */
+  public void updateTimeLevelFormat(AnalyzerDateFormatAnnotation annotation) {
+    timeLevelFormat = annotation.getTimeLevelFormat();
   }
 
   @Override

--- a/src/org/pentaho/agilebi/modeler/nodes/DimensionMetaData.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/DimensionMetaData.java
@@ -41,7 +41,12 @@ public class DimensionMetaData extends AbstractMetaDataModelNode<HierarchyMetaDa
   }
   
   public DimensionMetaData( String name ) {
+    this(name, "StandardDimension");
+  }
+
+  public DimensionMetaData( String name,  String dimensionType) {
     this.name = name;
+    this.dimensionType = dimensionType;
   }
 
   @Bindable

--- a/src/org/pentaho/agilebi/modeler/nodes/HierarchyMetaData.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/HierarchyMetaData.java
@@ -27,6 +27,7 @@ import org.pentaho.ui.xul.stereotype.Bindable;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Event aware node class that also listens to it's children's events and propagates them up.
@@ -38,7 +39,6 @@ public class HierarchyMetaData extends AbstractMetaDataModelNode<LevelMetaData> 
   String name;
 
   public HierarchyMetaData(){
-    
   }
 
   public HierarchyMetaData( String name ) {
@@ -78,6 +78,10 @@ public class HierarchyMetaData extends AbstractMetaDataModelNode<LevelMetaData> 
 
   public void dimensionTypeChanged() {
     validate();
+  }
+  
+  public List<LevelMetaData> getLevels(){
+    return (List<LevelMetaData>)this.children;
   }
   
   @Override

--- a/src/org/pentaho/agilebi/modeler/nodes/TimeRole.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/TimeRole.java
@@ -46,8 +46,21 @@ public class TimeRole implements DataRole {
    **/
   @Bindable
   public String getMondrianAttributeValue() {
-    String name = this.name;
-    return name.substring(0, 1).toUpperCase() + name.substring(1) + "s";
+    return "Time" + this.name;
+  }
+  
+  /**
+   * 
+   */
+  public static String mondrianAttributeValueToRoleName(String mondrianAttributeValue){
+    return mondrianAttributeValue.substring("Time".length());
+  }
+  
+  public static TimeRole fromMondrianAttributeValue(String mondrianAttributeValue){
+    for (TimeRole role : allRoles) {
+      if (role.getMondrianAttributeValue().equals(mondrianAttributeValue)) return role;
+    }
+    return null;
   }
 
   public boolean equals(Object obj) {
@@ -64,31 +77,32 @@ public class TimeRole implements DataRole {
   
   /* basic time roles */
   public static final TimeRole DUMMY = new TimeRole("");
-  public static final TimeRole YEAR = new TimeRole("year");
-  public static final TimeRole HALFYEAR = new TimeRole("halfYear");
-  public static final TimeRole QUARTER= new TimeRole("quarter");
-  public static final TimeRole MONTH= new TimeRole("month");
-  public static final TimeRole WEEK= new TimeRole("week");
-  public static final TimeRole DAY= new TimeRole("day");
-  public static final TimeRole HOUR = new TimeRole("hour");
-  public static final TimeRole MINUTE = new TimeRole("minute");
-  public static final TimeRole SECOND = new TimeRole("second");
+  public static final TimeRole YEARS = new TimeRole("Years");
+  public static final TimeRole HALFYEARS = new TimeRole("HalfYears");
+  public static final TimeRole QUARTERS = new TimeRole("Quarters");
+  public static final TimeRole MONTHS = new TimeRole("Months");
+  public static final TimeRole WEEKS = new TimeRole("Weeks");
+  public static final TimeRole DAYS = new TimeRole("Days");
+  public static final TimeRole HOURS = new TimeRole("Hours");
+  public static final TimeRole MINUTES = new TimeRole("Minutes");
+  public static final TimeRole SECONDS = new TimeRole("Seconds");
   
   public static final TimeRole[] ALL_ROLES = new TimeRole[]{
     DUMMY,
-    YEAR,
-    HALFYEAR,
-    QUARTER,
-    MONTH,
-    WEEK,
-    DAY,
-    HOUR,
-    MINUTE,
-    SECOND
+    YEARS,
+    HALFYEARS,
+    QUARTERS,
+    MONTHS,
+    WEEKS,
+    DAYS,
+    HOURS,
+    MINUTES,
+    SECONDS
   };
 
-  public static final List getAllRoles(){
-    return Arrays.asList(ALL_ROLES);
+  private static final List<TimeRole> allRoles = Arrays.asList(ALL_ROLES);
+  public static final List<TimeRole> getAllRoles(){
+    return allRoles;
   }
 }
 

--- a/src/org/pentaho/agilebi/modeler/nodes/annotations/AnalyzerDateFormatAnnotation.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/annotations/AnalyzerDateFormatAnnotation.java
@@ -1,0 +1,143 @@
+package org.pentaho.agilebi.modeler.nodes.annotations;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.pentaho.agilebi.modeler.nodes.AbstractMetaDataModelNode;
+import org.pentaho.agilebi.modeler.nodes.LevelMetaData;
+import org.pentaho.agilebi.modeler.nodes.HierarchyMetaData;
+
+import org.pentaho.metadata.model.olap.OlapHierarchyLevel;
+import org.pentaho.metadata.model.olap.OlapAnnotation;
+
+public class AnalyzerDateFormatAnnotation implements IAnalyzerDateFormatAnnotation, PropertyChangeListener {
+  
+  protected String value;
+  public AnalyzerDateFormatAnnotation(String value){
+    this.value = value;
+  }
+  public AnalyzerDateFormatAnnotation(LevelMetaData levelMetaData){
+    this(levelMetaData.getFullTimeLevelFormat());
+  }
+  
+  @Override
+  public String getName() {
+    return IAnalyzerDateFormatAnnotation.NAME;
+  }
+
+  public String getValue(){
+    return value;
+  }
+  
+  public void setValue(String value) {
+    this.value = value;
+  }
+  
+  public void setValue(LevelMetaData levelMetaData) {
+    setValue(levelMetaData.getFullTimeLevelFormat());
+  }
+  
+  /**
+   * This pinches of the last part of the full formatstring.
+   * That last part is what we should be storing in the LevelMetaData node.
+   */
+  public String getTimeLevelFormat(){
+    String value = getValue();
+    if (value == null) return null;
+    String[] parts = value.split("\\" + IAnalyzerDateFormatAnnotation.SEPARATOR);
+    int numParts = parts.length;
+    String part = parts[numParts == 0 ? 0 : numParts - 1];
+    if (part.startsWith(IAnalyzerDateFormatAnnotation.MEMBER_START_QUOTE) && 
+        part.endsWith(IAnalyzerDateFormatAnnotation.MEMBER_END_QUOTE)
+    ) {
+      part = part.substring(1, part.length() - 1);
+    }
+    return part;
+  }
+  
+  public static String quoteTimeLevelFormat(String timeLevelFormat) {
+    return 
+        IAnalyzerDateFormatAnnotation.MEMBER_START_QUOTE +
+        timeLevelFormat +
+        IAnalyzerDateFormatAnnotation.MEMBER_END_QUOTE
+    ;
+  }
+  
+  @Override
+  public void saveAnnotations(Object obj) {
+    OlapHierarchyLevel level = (OlapHierarchyLevel) obj;
+    List<OlapAnnotation> annotations = level.getAnnotations();
+    //remove the current AnalyzerDateFormatAnnotation if it exists
+    OlapAnnotation existingAnnotation = null;
+    for (OlapAnnotation annotation : annotations) {
+      if (!annotation.getName().equals(getName())) continue;
+      existingAnnotation = annotation; break;
+    }
+    if (existingAnnotation == null) {
+      annotations.add(new OlapAnnotation(getName(), getValue()));
+    }
+    else {
+      existingAnnotation.setValue(getValue());
+    }
+  }
+
+  @Override
+  public boolean isValid(AbstractMetaDataModelNode node) {
+    LevelMetaData levelMetaData = (LevelMetaData) node;
+    HierarchyMetaData hierarchyMetaData = levelMetaData.getHierarchyMetaData();
+    List<LevelMetaData> levels = hierarchyMetaData.getLevels();
+    for (LevelMetaData ancestor : levels) {
+      if (ancestor == node) return true;
+      if (ancestor.getTimeLevelFormat() == null) return false;
+    }
+    return true;
+  }
+
+  @Override
+  public List<String> getValidationMessages(AbstractMetaDataModelNode node) {
+    List<String> messages = null;
+    LevelMetaData levelMetaData = (LevelMetaData) node;
+    HierarchyMetaData hierarchyMetaData = levelMetaData.getHierarchyMetaData();
+    List<LevelMetaData> levels = hierarchyMetaData.getLevels();
+    for (LevelMetaData ancestor : levels) {
+      if (ancestor == node) break;
+      if (ancestor.getTimeLevelFormat() != null) continue;
+      if (messages == null) messages = new ArrayList<String>();
+      messages.add("Missing Time Level Format in level " + ancestor.getName());
+    } 
+    return messages;
+  }
+
+  @Override
+  public void onAttach(AbstractMetaDataModelNode node) {
+    if (!(node instanceof LevelMetaData)) return;
+    LevelMetaData levelMetaData = (LevelMetaData)node;
+    levelMetaData.updateTimeLevelFormat(this);
+    levelMetaData.addPropertyChangeListener("timeLevelFormat", this);
+  }
+
+  
+  @Override
+  public void onDetach(AbstractMetaDataModelNode node) {
+    if (!(node instanceof LevelMetaData)) return;
+    LevelMetaData levelMetaData = (LevelMetaData)node;
+    levelMetaData.removePropertyChangeListener(this);
+  }
+
+  @Override
+  public void propertyChange(PropertyChangeEvent evt) {
+    if (!"timeLevelFormat".equals(evt.getPropertyName())) return;
+    Object source = evt.getSource();
+    if (!(source instanceof LevelMetaData)) return;
+    LevelMetaData levelMetaData = (LevelMetaData) source;
+    value = levelMetaData.getFullTimeLevelFormat();
+    if (this.value == null && value == null) return;
+    if (this.value != null && value != null && this.value.equals(value)) return;
+    this.value = value;
+  }
+  
+}

--- a/src/org/pentaho/agilebi/modeler/nodes/annotations/AnalyzerDateFormatAnnotationFactory.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/annotations/AnalyzerDateFormatAnnotationFactory.java
@@ -1,0 +1,23 @@
+package org.pentaho.agilebi.modeler.nodes.annotations;
+
+import org.pentaho.metadata.model.olap.OlapAnnotation;
+import org.pentaho.agilebi.modeler.nodes.LevelMetaData;
+
+public class AnalyzerDateFormatAnnotationFactory implements IAnnotationFactory {
+
+  public static AnalyzerDateFormatAnnotationFactory instance = new AnalyzerDateFormatAnnotationFactory();
+  public static void register(){
+    MemberAnnotationFactory.registerFactory(IAnalyzerDateFormatAnnotation.NAME, AnalyzerDateFormatAnnotationFactory.instance);
+  }
+  private AnalyzerDateFormatAnnotationFactory() {
+    
+  }
+  @Override
+  public IMemberAnnotation create(OlapAnnotation anno) {
+    return new AnalyzerDateFormatAnnotation(anno.getValue());
+  }
+
+  public IMemberAnnotation create(LevelMetaData levelMetaData) {
+    return new AnalyzerDateFormatAnnotation(levelMetaData);
+  }
+}

--- a/src/org/pentaho/agilebi/modeler/nodes/annotations/GeoAnnotationFactory.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/annotations/GeoAnnotationFactory.java
@@ -6,8 +6,8 @@ import org.pentaho.agilebi.modeler.geo.LocationRole;
 import org.pentaho.metadata.model.olap.OlapAnnotation;
 
 /**
- * This factory is used to rehydrate annotations forthe Modeler model form a saved state.
- * It takes in an OlapConnection from the saved model and returns the higher-level coresponding
+ * This factory is used to rehydrate annotations for the Modeler model form a saved state.
+ * It takes in an OlapAnnotation from the saved model and returns the higher-level corresponding
  * Object
  *
  * User: nbaker

--- a/src/org/pentaho/agilebi/modeler/nodes/annotations/IAnalyzerDateFormatAnnotation.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/annotations/IAnalyzerDateFormatAnnotation.java
@@ -1,0 +1,15 @@
+/**
+ * 
+ */
+package org.pentaho.agilebi.modeler.nodes.annotations;
+
+/**
+ * @author rbouman
+ *
+ */
+public interface IAnalyzerDateFormatAnnotation extends IMemberAnnotation {
+  public final static String NAME = "AnalyzerDateFormat";
+  public final static String SEPARATOR = ".";
+  public final static String MEMBER_START_QUOTE = "[";
+  public final static String MEMBER_END_QUOTE = "]";
+}

--- a/src/org/pentaho/agilebi/modeler/nodes/annotations/MemberAnnotationFactory.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/annotations/MemberAnnotationFactory.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This factory is used to rehydrate annotations from saved state. IAnotation factories are regiered for annotation
+ * This factory is used to rehydrate annotations from saved state. IAnotation factories are registered for annotation
  * keys (Geo.Role, Data.Role, etc) and are called on to recreate the Modeler annotation objects from Metadata versions.
  *
  * User: nbaker

--- a/src/org/pentaho/agilebi/modeler/propforms/LevelsPropertiesForm.java
+++ b/src/org/pentaho/agilebi/modeler/propforms/LevelsPropertiesForm.java
@@ -61,6 +61,8 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
   protected XulButton messageBtn;
   protected XulMenuList geoList;
   protected XulMenuList timeLevelTypeList;
+  protected XulMenuList timeLevelFormatList;
+  protected String timeLevelFormat;
 
   protected List<GeoRole> geoRoles = new ArrayList<GeoRole>();
   protected GeoRole selectedGeoRole;
@@ -82,8 +84,10 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
           propertyName.equals("logicalColumn") ||
           propertyName.equals("logicalOrdinalColumn") ||
           propertyName.equals("ordinalColumnName") ||
-          propertyName.equals("logicalCaptionColumn")
+          propertyName.equals("logicalCaptionColumn") ||
+          propertyName.equals("timeLevelFormat")
        ) {
+        System.out.println("PropertyChange: " + propertyName);
         showValidations();
       }
     }
@@ -120,6 +124,8 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
       setTimeLevelElementsVisible(true);
       DataRole dataRole = getNode().getDataRole();
       setSelectedTimeLevelType(dataRole instanceof TimeRole ? ((TimeRole)dataRole) : TimeRole.DUMMY);
+      String timeLevelFormat = getNode().getTimeLevelFormat();
+      this.timeLevelFormatList.setValue(timeLevelFormat == null ? "" : timeLevelFormat);
     }
     else {
       setGeoLevelElementsVisible(true);
@@ -138,7 +144,6 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
     if (getNode() == null) {
       return;
     }
-
     setNotValid(!getNode().isValid());
     LogicalColumn logicalColumn; 
 
@@ -213,7 +218,11 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
     timeLevelTypeList.setElements(timeRoles);
     
     bf.createBinding(timeLevelTypeList, "selectedItem", this, "selectedTimeLevelType");
-  }
+
+    timeLevelFormatList = (XulMenuList) document.getElementById("time_level_format");
+    bf.createBinding(timeLevelFormatList, "value", this, "timeLevelFormat");
+    bf.createBinding(timeLevelFormatList, "selectedItem", this, "timeLevelFormat");
+}
 
   protected String getColumnNameFromLogicalColumn(LogicalColumn col ) {
     String columnName = ""; //$NON-NLS-1$
@@ -376,4 +385,26 @@ public class LevelsPropertiesForm extends AbstractModelerNodeForm<BaseColumnBack
     getNode().setDataRole(selectedTimeLevelType);
     firePropertyChange("selectedTimeLevelType", oldTimeLevelType, selectedTimeLevelType);
   }
+  
+  @Bindable
+  public void setTimeLevelFormat( String format ) {
+    if ("".equals(format)) format = null;
+    if (format == null && timeLevelFormat == null) return;
+    if (format != null && timeLevelFormat != null && format.equals(timeLevelFormat)) return;
+    if (getNode() != null) {
+      getNode().setTimeLevelFormat(format);
+    }
+    getNode().validateNode();
+    showValidations();
+    timeLevelFormat = format;
+  }
+
+  @Bindable
+  public String getTimeLevelFormat() {
+    if (getNode() == null) {
+      return null;
+    }
+    return getNode().getTimeLevelFormat();
+  }
+  
 }

--- a/src/org/pentaho/agilebi/modeler/res/cubeForms.xul
+++ b/src/org/pentaho/agilebi/modeler/res/cubeForms.xul
@@ -239,11 +239,12 @@
         </hbox>
         <menulist id="time_level_format" editable="true">
           <menupopup>
-            <menuitem label="[yyyy]"/>
-            <menuitem label="[yyyy].[q]"/>
-            <menuitem label="[yyyy].[q].[M]"/>
-            <menuitem label="[yyyy].[q].[M].[w]"/>
-            <menuitem label="[yyyy].[q].[M].[w].[yyyy-MM-dd]"/>
+            <menuitem label=""/>
+            <menuitem label="yyyy"/>
+            <menuitem label="q"/>
+            <menuitem label="M"/>
+            <menuitem label="w"/>
+            <menuitem label="yyyy-MM-dd"/>
           </menupopup>
         </menulist>
       </vbox>

--- a/src/org/pentaho/agilebi/modeler/util/ModelerWorkspaceUtil.java
+++ b/src/org/pentaho/agilebi/modeler/util/ModelerWorkspaceUtil.java
@@ -68,10 +68,7 @@ public class ModelerWorkspaceUtil {
     try {
 
       String xml = getMondrianSchemaXml(aModel, locale);
-      if (xml == null) {
-        System.out.println("xml == null; exiting...");
-        return;
-      }
+      if (xml == null) return;
       // write the XMI to a tmp file
       // models was created earlier.
       try{
@@ -96,10 +93,7 @@ public class ModelerWorkspaceUtil {
   public static String getMondrianSchemaXml(ModelerWorkspace modelerWorkspace, String locale) throws Exception {
     modelerWorkspace.getWorkspaceHelper().populateDomain(modelerWorkspace);
     LogicalModel logicalModel = modelerWorkspace.getLogicalModel(ModelerPerspective.ANALYSIS);
-    if (logicalModel == null) {
-      System.out.println("Logical model == null");
-      return null;
-    }
+    if (logicalModel == null) return null;
     MondrianModelExporter exporter = new MondrianModelExporter(logicalModel, locale);
     return exporter.createMondrianModelXML();
   }


### PR DESCRIPTION
Allow IMemberAnnotation.getValidationMessages() to return null.
This makes it slightly easier to write IMemberAnnotation instances since the may now return null instead of Collections.emptyList()

Fixed a few typos in the comments

Fixed a few typos in the comments.

Added ability to save timelevelformat property and generate AnalyzerTimeLevelFormat annotations.

Made closer match to mondrian level types.

Removed debug messages.

Added constructor that allows you to set the dimension type.

Added null check for setting the levelType.

Handle properties added for BISERVER-6823

Cleanup.

Removed some debugging messages.

Finished implementing AnalyzerDateFormat Annotations, added validations.
