### PR TITLE
Offer specific time formats depending on time level type.

### DIFF
--- a/src/org/pentaho/agilebi/modeler/ColResolverController.java
+++ b/src/org/pentaho/agilebi/modeler/ColResolverController.java
@@ -61,6 +61,11 @@ public class ColResolverController extends AbstractXulEventHandler {
       items.addAll(workspace.getAvailableTables());
     }
     this.node = node;
+    dialog.setTitle(
+        ModelerMessagesHolder.getMessages().getString(
+            "ColResolverController." + columnType + "_column_selection_dialog"
+        )
+    );
     dialog.show();
   }
 

--- a/src/org/pentaho/agilebi/modeler/messages/messages_en_US.properties
+++ b/src/org/pentaho/agilebi/modeler/messages/messages_en_US.properties
@@ -192,3 +192,7 @@ geo.state=State
 geo.postal_code=Postal Code
 geo.continent=Continent
 geo.territory=Territory
+
+ColResolverController.source_column_selection_dialog=Select Source Column
+ColResolverController.ordinal_column_selection_dialog=Select Ordinal Column
+ColResolverController.caption_column_selection_dialog=Select Caption Column

--- a/src/org/pentaho/agilebi/modeler/nodes/DimensionMetaData.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/DimensionMetaData.java
@@ -96,8 +96,7 @@ public class DimensionMetaData extends AbstractMetaDataModelNode<HierarchyMetaDa
   public void setTimeDimension(boolean timeDimension) {
     boolean oldTimeDimension = isTimeDimension();
     if (timeDimension == oldTimeDimension) return;
-    //TODO: call setDimensionType rather than writing the member.
-    dimensionType = timeDimension ? "TimeDimension" : "StandardDimension";
+    setDimensionType(timeDimension ? "TimeDimension" : "StandardDimension");
     firePropertyChange("timeDimension", oldTimeDimension, timeDimension);
     validateNode();
   }
@@ -163,7 +162,7 @@ public class DimensionMetaData extends AbstractMetaDataModelNode<HierarchyMetaDa
 
   @Bindable
   public boolean isTime() {
-    return this.dataRole instanceof TimeRole;
+    return isTimeDimension();
   }
 
   @Bindable

--- a/src/org/pentaho/agilebi/modeler/nodes/TimeRole.java
+++ b/src/org/pentaho/agilebi/modeler/nodes/TimeRole.java
@@ -17,9 +17,13 @@ public class TimeRole implements DataRole {
 
   private static final String DEFAULT_NAME = "time";
   public String name;
+  public String[] formats;
+  public List<String> formatsList;
 
-  public TimeRole(String name) {
+  public TimeRole(String name, String[] formats) {
     this.name = name;
+    this.formats = formats;
+    this.formatsList = Arrays.asList(formats);
   }
   
   @Bindable
@@ -37,6 +41,10 @@ public class TimeRole implements DataRole {
   
   public String toString() {
     return getName();
+  }
+  
+  public List<String>getFormatsList() {
+    return this.formatsList;
   }
   
   /**
@@ -76,16 +84,32 @@ public class TimeRole implements DataRole {
   }
   
   /* basic time roles */
-  public static final TimeRole DUMMY = new TimeRole("");
-  public static final TimeRole YEARS = new TimeRole("Years");
-  public static final TimeRole HALFYEARS = new TimeRole("HalfYears");
-  public static final TimeRole QUARTERS = new TimeRole("Quarters");
-  public static final TimeRole MONTHS = new TimeRole("Months");
-  public static final TimeRole WEEKS = new TimeRole("Weeks");
-  public static final TimeRole DAYS = new TimeRole("Days");
-  public static final TimeRole HOURS = new TimeRole("Hours");
-  public static final TimeRole MINUTES = new TimeRole("Minutes");
-  public static final TimeRole SECONDS = new TimeRole("Seconds");
+  public static final TimeRole DUMMY = new TimeRole("", new String[]{});
+  public static final TimeRole YEARS = new TimeRole("Years", new String[]{
+    "yy", "yyyy"
+  });
+  public static final TimeRole HALFYEARS = new TimeRole("HalfYears", new String[]{});
+  public static final TimeRole QUARTERS = new TimeRole("Quarters", new String[]{
+    "Q", "QQ", "QQQ"
+  });
+  public static final TimeRole MONTHS = new TimeRole("Months", new String[]{
+    "M", "MM", "MMM"
+  });
+  public static final TimeRole WEEKS = new TimeRole("Weeks", new String[]{
+    "w", "ww", "W"
+  });
+  public static final TimeRole DAYS = new TimeRole("Days", new String[]{
+    "d", "dd", "D", "DDD", "yyyy-MM-dd"
+  });
+  public static final TimeRole HOURS = new TimeRole("Hours", new String[]{
+    "k", "kk", "H", "HH", "K", "KK"
+  });
+  public static final TimeRole MINUTES = new TimeRole("Minutes", new String[]{
+    "m", "mm"
+  });
+  public static final TimeRole SECONDS = new TimeRole("Seconds", new String[]{
+    "s", "ss"
+  });
   
   public static final TimeRole[] ALL_ROLES = new TimeRole[]{
     DUMMY,
@@ -99,6 +123,13 @@ public class TimeRole implements DataRole {
     MINUTES,
     SECONDS
   };
+  
+  public static TimeRole findRoleByName(String name) {
+    for (TimeRole role : ALL_ROLES) {
+      if (role.getName().equals(name)) return role;
+    }
+    return null;
+  }
 
   private static final List<TimeRole> allRoles = Arrays.asList(ALL_ROLES);
   public static final List<TimeRole> getAllRoles(){

--- a/src/org/pentaho/agilebi/modeler/res/cubeForms.xul
+++ b/src/org/pentaho/agilebi/modeler/res/cubeForms.xul
@@ -36,6 +36,7 @@
       <hbox flex="1">
         <checkbox id="is_time_dimension" />
         <label value="${is_time_dimension}" />
+        <spacer flex="1"/>
       </hbox>
     </groupbox>
     
@@ -176,6 +177,7 @@
       <hbox flex="1">
         <checkbox id="has_unique_members" />
         <label value="${has_unique_members}" />
+        <spacer flex="1"/>
       </hbox>
 
       <label value="${source_column}:" flex="1"/>
@@ -229,12 +231,12 @@
         <menulist id="time_level_type" pen:binding="name">
             <menupopup/>
         </menulist>
-      
+              
         <hbox>
           <label id="time_level_format_label" value="${time_format}:"/>
           <button
             image="images/help_link2.png"
-            onclick="modeler.showHelp('${time_format_help_url}')"
+            tooltiptext="View data formatting documentation in Pentaho Infocenter."
           />
         </hbox>
         <menulist id="time_level_format" editable="true">

--- a/test-res/products.mondrian.xml
+++ b/test-res/products.mondrian.xml
@@ -6,7 +6,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="BUYPRICE" column="BUYPRICE" type="Numeric" uniqueMembers="false">
+      <Level name="BUYPRICE" uniqueMembers="false" column="BUYPRICE" type="Numeric">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -17,7 +17,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="MSRP" column="MSRP" type="Numeric" uniqueMembers="false">
+      <Level name="MSRP" uniqueMembers="false" column="MSRP" type="Numeric">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -28,7 +28,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTCODE" column="PRODUCTCODE" type="String" uniqueMembers="false">
+      <Level name="PRODUCTCODE" uniqueMembers="false" column="PRODUCTCODE" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -39,7 +39,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTDESCRIPTION" column="PRODUCTDESCRIPTION" type="String" uniqueMembers="false">
+      <Level name="PRODUCTDESCRIPTION" uniqueMembers="false" column="PRODUCTDESCRIPTION" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -50,7 +50,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTLINE" column="PRODUCTLINE" type="String" uniqueMembers="false">
+      <Level name="PRODUCTLINE" uniqueMembers="false" column="PRODUCTLINE" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -61,7 +61,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTNAME" column="PRODUCTNAME" type="String" uniqueMembers="false">
+      <Level name="PRODUCTNAME" uniqueMembers="false" column="PRODUCTNAME" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -72,7 +72,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTSCALE" column="PRODUCTSCALE" type="String" uniqueMembers="false">
+      <Level name="PRODUCTSCALE" uniqueMembers="false" column="PRODUCTSCALE" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -83,7 +83,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="PRODUCTVENDOR" column="PRODUCTVENDOR" type="String" uniqueMembers="false">
+      <Level name="PRODUCTVENDOR" uniqueMembers="false" column="PRODUCTVENDOR" type="String">
       </Level>
     </Hierarchy>
   </Dimension>
@@ -94,7 +94,7 @@
          <![CDATA[select * from products]]>
         </SQL>
     </View>
-      <Level name="QUANTITYINSTOCK" column="QUANTITYINSTOCK" type="Numeric" uniqueMembers="false">
+      <Level name="QUANTITYINSTOCK" uniqueMembers="false" column="QUANTITYINSTOCK" type="Numeric">
       </Level>
     </Hierarchy>
   </Dimension>


### PR DESCRIPTION
Added spacer to push labels right next to checkboxes.

Redefined isTime() method in terms of isTimeDimension(); rewrote setTimeDimension using setDimensionType.

Fix ModelerWorkspaceTest - uniqueMembers now appears directly after the columnName attribute.

Created custom dialog titles for the Column Resolver Dialog.

Offer specific time formats in the list depending on the time level type.
