### PR TITLE
PDI-9448 - Removed dependency on obsolete kettle-db jar

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -24,7 +24,6 @@
 
     <dependency org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
     <dependency org="pentaho-kettle" name="kettle-core" rev="${dependency.kettle.revision}" changing="true"/>
-    <dependency org="pentaho-kettle" name="kettle-db" rev="${dependency.kettle.revision}" transitive="false" conf="default->default" changing="true" />
 
     <dependency org="org.slf4j" name="slf4j-api" rev="1.5.8" conf="default->default" />
     <dependency org="org.slf4j" name="slf4j-jcl" rev="1.5.8" conf="default->default" />


### PR DESCRIPTION
Kettle DB has been incorporated into Kettle Core and Kettle Engine and is no longer needed
