### PR TITLE
[PPP-3272] - Update all current "infocenter" references to "mind touch"

### DIFF
--- a/src/org/pentaho/agilebi/modeler/res/cubeForms.properties
+++ b/src/org/pentaho/agilebi/modeler/res/cubeForms.properties
@@ -13,5 +13,5 @@ geo_role=Geography Type
 time_level_type=Time Level Type
 more=More...
 time_format=Source Column Format
-time_format_help_tooltip=View formatting documentation in Pentaho Infocenter.
-time_format_help_url=http://infocenter.pentaho.com/help/topic/puc_user_guide/reference_time_level_format.html
+time_format_help_tooltip=View formatting documentation in Pentaho InfoCenter.
+time_format_help_url=http://help.pentaho.com


### PR DESCRIPTION
- Updated link references from infocenter.pentaho.com to help.pentaho.com.
  - Tweaked references to InfoCenter to be consistently spelled (casing)
    InfoCenter is how the Doc team wants to refer to the help documentation
    at this point. No reference to MindTouch since it is only the
    implementation vehicle.
