### PR TITLE
[BACKLOG-1619] - cloning logical columns so that measures do not step on...

### DIFF
--- a/src/org/pentaho/agilebi/modeler/models/annotations/CreateMeasure.java
+++ b/src/org/pentaho/agilebi/modeler/models/annotations/CreateMeasure.java
@@ -106,23 +106,23 @@ public class CreateMeasure extends AnnotationType {
               (String) logicalColumn.getPhysicalColumn().getProperty( SqlPhysicalColumn.TARGET_COLUMN );
           MeasureMetaData measureMetaData =
               new MeasureMetaData( targetColumn, getFormatString(), getName(), workspace.getWorkspaceHelper().getLocale() );
-          measureMetaData.setLogicalColumn( logicalColumn );
-          measureMetaData.setDefaultAggregation( getAggregateType() );
           measureMetaData.setName( getName() );
-          workspace.addMeasure( measureMetaData );
+          measureMetaData.setLogicalColumn( (LogicalColumn) logicalColumn.clone() );
+          measureMetaData.setDefaultAggregation( getAggregateType() );
+          workspace.getModel().getMeasures().add( measureMetaData );
           workspace.getWorkspaceHelper().populateDomain( workspace );
           return true;
         }
       }
 
     }
-    return true;
+    throw new ModelerException( "Unable to apply Create Measure annotation: Column not found" );
   }
 
   @Override
   public boolean apply( Document doc, String field ) throws ModelerException {
     // Surgically add the measure into the cube...
-    try {      
+    try {
       XPathFactory xPathFactory = XPathFactory.newInstance();
       XPath xPath = xPathFactory.newXPath();
       StringBuffer xPathExpr = new StringBuffer();
@@ -134,13 +134,13 @@ public class CreateMeasure extends AnnotationType {
       cube.appendChild( measureElement ); // TODO: Measures need to come after calculated measures
       measureElement.setAttribute( "name", getName() );
       measureElement.setAttribute( "column", field );
-      measureElement.setAttribute( "aggregator", MondrianModelExporter.convertToMondrian( getAggregateType() ));
-    } catch (XPathExpressionException e) {
-      throw new ModelerException (e);
+      measureElement.setAttribute( "aggregator", MondrianModelExporter.convertToMondrian( getAggregateType() ) );
+    } catch ( XPathExpressionException e ) {
+      throw new ModelerException( e );
     }
     return true;
   }
-  
+
   @Override
   public void populate( final Map<String, Serializable> propertiesMap ) {
 

--- a/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateMeasureTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateMeasureTest.java
@@ -41,6 +41,7 @@ import static junit.framework.Assert.assertEquals;
 import static org.pentaho.metadata.model.LogicalModel.PROPERTY_OLAP_CUBES;
 import static org.pentaho.metadata.model.SqlPhysicalColumn.TARGET_COLUMN;
 import static org.pentaho.metadata.model.concept.types.AggregationType.AVERAGE;
+import static org.pentaho.metadata.model.concept.types.AggregationType.MAXIMUM;
 import static org.pentaho.metadata.model.concept.types.AggregationType.MINIMUM;
 
 public class CreateMeasureTest {
@@ -129,7 +130,7 @@ public class CreateMeasureTest {
     assertEquals( "##.##", measureMetaData.getFormat() );
     assertEquals( MINIMUM, measureMetaData.getDefaultAggregation() );
   }
-  
+
   /**
    * Verified that we can create a new measure using an existing hierarchy as the source.
    * 
@@ -158,5 +159,37 @@ public class CreateMeasureTest {
     assertEquals( "Product Count", measureMetaData.getName() );
     assertEquals( "##.##", measureMetaData.getFormat() );
     assertEquals( AggregationType.COUNT_DISTINCT, measureMetaData.getDefaultAggregation() );
+  }
+
+  @Test
+  public void testCanCreateMultipleMeasuresOnSameColumn() throws Exception {
+    CreateMeasure minWeight = new CreateMeasure();
+    minWeight.setAggregateType( MINIMUM );
+    minWeight.setName( "Min Weight" );
+    minWeight.setFormatString( "##.##" );
+
+    CreateMeasure maxWeight = new CreateMeasure();
+    maxWeight.setAggregateType( MAXIMUM );
+    maxWeight.setName( "Max Weight" );
+    maxWeight.setFormatString( "##.##" );
+
+    ModelerWorkspace model =
+        new ModelerWorkspace( new ModelerWorkspaceHelper( "" ) );
+    model.setDomain( new XmiParser().parseXmi( new FileInputStream( "test-res/products.xmi" ) ) );
+    minWeight.apply( model, "bc_QUANTITYINSTOCK" );
+    maxWeight.apply( model, "bc_QUANTITYINSTOCK" );
+    MeasuresCollection measures = model.getModel().getMeasures();
+    assertEquals( 5, measures.size() );
+    MeasureMetaData minMeta = measures.get( 3 );
+    assertEquals( "QUANTITYINSTOCK", minMeta.getColumnName() );
+    assertEquals( "Min Weight", minMeta.getName() );
+    assertEquals( "##.##", minMeta.getFormat() );
+    assertEquals( MINIMUM, minMeta.getDefaultAggregation() );
+
+    MeasureMetaData maxMeta = measures.get( 4 );
+    assertEquals( "QUANTITYINSTOCK", maxMeta.getColumnName() );
+    assertEquals( "Max Weight", maxMeta.getName() );
+    assertEquals( "##.##", maxMeta.getFormat() );
+    assertEquals( MAXIMUM, maxMeta.getDefaultAggregation() );
   }
 }


### PR DESCRIPTION
... each other.  Throwing an exception when column not found when attempting to create a measure.
