### PR TITLE
[BACKLOG-1871] - The level needs to attach to the hierarchy before all t...

### DIFF
--- a/src/org/pentaho/agilebi/modeler/models/annotations/CreateAttribute.java
+++ b/src/org/pentaho/agilebi/modeler/models/annotations/CreateAttribute.java
@@ -266,8 +266,10 @@ public class CreateAttribute extends AnnotationType {
     }
     LevelMetaData existingLevel = locateLevel( workspace, column );
     LevelMetaData ordinalAutoLevel = locateLevel( workspace, getOrdinalField() );
-    LevelMetaData levelMetaData = buildLevel( workspace, hierarchyMetaData, locateLogicalColumn( workspace, column ) );
+    LogicalColumn logicalColumn = locateLogicalColumn( workspace, column );
+    LevelMetaData levelMetaData = new LevelMetaData( hierarchyMetaData, getName() );
     hierarchyMetaData.add( levelMetaData );
+    fillLevelProperties( workspace, logicalColumn, levelMetaData );
     removeAutoLevel( workspace, existingLevel );
     removeAutoMeasure( workspace, column );
     removeAutoLevel( workspace, ordinalAutoLevel );
@@ -300,10 +302,8 @@ public class CreateAttribute extends AnnotationType {
     return OlapDimension.TYPE_STANDARD_DIMENSION;
   }
 
-  private LevelMetaData buildLevel( final ModelerWorkspace workspace,
-                                    final HierarchyMetaData hierarchyMetaData, final LogicalColumn logicalColumn )
-    throws ModelerException {
-    LevelMetaData levelMetaData = new LevelMetaData( hierarchyMetaData, getName() );
+  private void fillLevelProperties( final ModelerWorkspace workspace, final LogicalColumn logicalColumn,
+                                    final LevelMetaData levelMetaData ) {
     levelMetaData.setLogicalColumn( logicalColumn );
     levelMetaData.setUniqueMembers( isUnique() );
     if ( getTimeType() != null ) {
@@ -323,7 +323,6 @@ public class CreateAttribute extends AnnotationType {
         geoRole.setRequiredParentRoles( locateParentGeoRole( workspace ) );
       }
     }
-    return levelMetaData;
   }
 
   private List<GeoRole> locateParentGeoRole( final ModelerWorkspace workspace ) {
@@ -361,8 +360,10 @@ public class CreateAttribute extends AnnotationType {
     } else {
       LevelMetaData existingLevel = locateLevel( workspace, column );
       LevelMetaData ordinalAutoLevel = locateLevel( workspace, getOrdinalField() );
-      LevelMetaData levelMetaData = buildLevel( workspace, existingHierarchy, locateLogicalColumn( workspace, column ) );
+      LogicalColumn logicalColumn = locateLogicalColumn( workspace, column );
+      LevelMetaData levelMetaData = new LevelMetaData( existingHierarchy, getName() );
       existingHierarchy.add( parentIndex + 1, levelMetaData );
+      fillLevelProperties( workspace, logicalColumn, levelMetaData );
       removeAutoLevel( workspace, existingLevel );
       removeAutoMeasure( workspace, column );
       removeAutoLevel( workspace, ordinalAutoLevel );

--- a/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateAttributeTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateAttributeTest.java
@@ -108,9 +108,10 @@ public class CreateAttributeTest {
     List<OlapHierarchyLevel> dateLevels = dateHierarchy.getHierarchyLevels();
     assertEquals( "Year", dateLevels.get( 0 ).getName() );
     assertEquals( "TimeYears", dateLevels.get( 0 ).getLevelType() );
+    assertEquals( "[yyyy]", dateLevels.get( 0 ).getAnnotations().get( 0 ).getValue() );
     assertEquals( "Month", dateLevels.get( 1 ).getName() );
     assertEquals( "TimeMonths", dateLevels.get( 1 ).getLevelType() );
-    assertEquals( "[yyyy]", dateLevels.get( 1 ).getAnnotations().get( 0 ).getValue() );
+    assertEquals( "[yyyy].[mm]", dateLevels.get( 1 ).getAnnotations().get( 0 ).getValue() );
 
   }
 


### PR DESCRIPTION
...he properties are set because there are some change listeners that set additional properties and depend on finding siblings.