### PR TITLE
[BACKLOG-2343] - switching from checks for shared dimension from an empt...

### DIFF
--- a/src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotation.java
+++ b/src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotation.java
@@ -313,7 +313,7 @@ public class ModelAnnotation<T extends AnnotationType> implements Serializable {
           final ModelAnnotationGroup modelAnnotations,
           final ModelAnnotation modelAnnotation,
           final ValueMetaInterface valueMeta ) {
-        return modelAnnotations.getDataProviders() == null || modelAnnotations.getDataProviders().isEmpty();
+        return !modelAnnotations.isSharedDimension();
       }
     },
     CREATE_ATTRIBUTE( "Create Attribute" ) {
@@ -328,7 +328,7 @@ public class ModelAnnotation<T extends AnnotationType> implements Serializable {
       @Override public boolean isApplicable(
           final ModelAnnotationGroup modelAnnotations, final ModelAnnotation modelAnnotation,
           final ValueMetaInterface valueMeta ) {
-        return !modelAnnotations.getDataProviders().isEmpty()
+        return modelAnnotations.isSharedDimension()
             && ( isDimensionKey( modelAnnotation ) || !hasDimensionKey( modelAnnotations ) );
       }
 

--- a/test-src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotationTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotationTest.java
@@ -130,7 +130,7 @@ public class ModelAnnotationTest {
   @Test
   public void testDimensionKeyOnlyAppliesToSharedDimensions() throws Exception {
     ModelAnnotationGroup modelAnnotations = new ModelAnnotationGroup();
-    modelAnnotations.setDataProviders( Arrays.asList( new DataProvider() ) );
+    modelAnnotations.setSharedDimension( true );
     assertTrue(
         ModelAnnotation.Type.CREATE_DIMENSION_KEY
             .isApplicable( modelAnnotations, new ModelAnnotation(), new ValueMetaInteger() ) );
@@ -142,7 +142,7 @@ public class ModelAnnotationTest {
   @Test
   public void testDimensionKeyOnlyAppliesOncePerGroup() throws Exception {
     ModelAnnotationGroup modelAnnotations = new ModelAnnotationGroup();
-    modelAnnotations.setDataProviders( Arrays.asList( new DataProvider() ) );
+    modelAnnotations.setSharedDimension( true );
     assertTrue(
         ModelAnnotation.Type.CREATE_DIMENSION_KEY
             .isApplicable( modelAnnotations, new ModelAnnotation(), new ValueMetaInteger() ) );
@@ -171,13 +171,13 @@ public class ModelAnnotationTest {
     assertTrue(
         ModelAnnotation.Type.CREATE_MEASURE
             .isApplicable( modelAnnotations, new ModelAnnotation(), new ValueMetaInteger() ) );
-    modelAnnotations.setDataProviders( Arrays.asList( new DataProvider() ) );
+    modelAnnotations.setSharedDimension( true );
     assertFalse(
         ModelAnnotation.Type.CREATE_MEASURE
             .isApplicable( modelAnnotations, new ModelAnnotation(), new ValueMetaInteger() ) );
 
 
-    modelAnnotations.setDataProviders( new ArrayList<DataProvider>(  ) ); // clear data providers
+    modelAnnotations.setSharedDimension( false );
     assertTrue(
         ModelAnnotation.Type.CREATE_MEASURE
             .isApplicable( modelAnnotations, new ModelAnnotation(), new ValueMetaInteger() ) );


### PR DESCRIPTION
...y data providers list to the explicit method