### PR TITLE
[BACKLOG-3700] - some metastore implementations won't handle the situ…

### DIFF
--- a/src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotationManager.java
+++ b/src/org/pentaho/agilebi/modeler/models/annotations/ModelAnnotationManager.java
@@ -173,7 +173,8 @@ public class ModelAnnotationManager {
 
   public DatabaseMeta loadDatabaseMeta( String databaseMetaRefName, IMetaStore mstore ) throws MetaStoreException,
       KettlePluginException {
-    IMetaStoreElementType dbMetaType = DatabaseMetaStoreUtil.populateDatabaseElementType( mstore );
+    IMetaStoreElementType dbMetaType =
+        mstore.getElementTypeByName( PentahoDefaults.NAMESPACE, PentahoDefaults.DATABASE_CONNECTION_ELEMENT_TYPE_NAME );
     IMetaStoreElement element = mstore.getElementByName( dbMetaType.getNamespace(), dbMetaType, databaseMetaRefName );
     if ( element == null ) {
       return null;


### PR DESCRIPTION
…ation where it is passed an element type with a null id.  This change first gets the element type from the metastore instead of constructing it from the name so that it will always have an id.