### PR TITLE
[BACKLOG-8242] - Create Dimension Key summary should use field instea…

### DIFF
--- a/src/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKey.java
+++ b/src/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKey.java
@@ -118,7 +118,7 @@ public class CreateDimensionKey extends AnnotationType {
 
   @Override
   public String getSummary() {
-    return BaseMessages.getString( MSG_CLASS, "Modeler.CreateDimensionKey.Summary", getName(), getDimension() );
+    return BaseMessages.getString( MSG_CLASS, "Modeler.CreateDimensionKey.Summary", getField(), getDimension() );
   }
 
   @Override

--- a/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKeyTest.java
+++ b/test-src/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKeyTest.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2015 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2016 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -87,7 +87,8 @@ public class CreateDimensionKeyTest {
   @Test
   public void testSummary() throws Exception {
     CreateDimensionKey createKey = new CreateDimensionKey();
-    createKey.setName( "field1" );
+    createKey.setName( "name" );
+    createKey.setField( "field1" );
     createKey.setDimension( "dim1" );
     LanguageChoice.getInstance().setDefaultLocale( Locale.US );
     final String summary = createKey.getSummary();

--- a/test-src/org/pentaho/agilebi/modeler/models/annotations/LinkDimensionIT.java
+++ b/test-src/org/pentaho/agilebi/modeler/models/annotations/LinkDimensionIT.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2015 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2016 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -168,7 +168,7 @@ public class LinkDimensionIT {
       "Dimension Product Dim is linked to shared dimension shared product group\n"
       + "    Unable to apply annotation: Description participates in hierarchy with parent Product\n"
       + "    Unable to apply annotation: Product is top level in hierarchy\n"
-      + "    Successfully applied annotation: id is key for dimension Shared Product dim",
+      + "    Successfully applied annotation: Id is key for dimension Shared Product dim",
       linkDimension.getSummary() );
   }
 


### PR DESCRIPTION
…d of name.  Meta injection will only inject field as it is the property actually used in applying the annotation