### PR TITLE
[BACKLOG-11410] - In Create Dimension Key, if field is null, use the …

### DIFF
--- a/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKey.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKey.java
@@ -100,11 +100,6 @@ public class CreateDimensionKey extends AnnotationType {
           BaseMessages.getString( MSG_CLASS, "ModelAnnotation.CreateAttribute.validation.ATTRIBUTE_NAME_REQUIRED" ) );
     }
 
-    if ( StringUtils.isBlank( getField() ) ) {
-      throw new ModelerException( BaseMessages.getString( MSG_CLASS,
-        "ModelAnnotation.CreateAttribute.validation.FIELD_NAME " ) );
-    }
-
     if ( StringUtils.isBlank( getDimension() ) ) {
       throw new ModelerException( BaseMessages.getString( MSG_CLASS,
           "ModelAnnotation.CreateAttribute.validation.PARENT_PROVIDED_MISSING_DIMENSION" ) );
@@ -123,6 +118,9 @@ public class CreateDimensionKey extends AnnotationType {
 
   @Override
   public String getField() {
+    if ( field == null ) {
+      setField( getName() );
+    }
     return field;
   }
 

--- a/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKeyTest.java
+++ b/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/CreateDimensionKeyTest.java
@@ -72,27 +72,15 @@ public class CreateDimensionKeyTest {
   }
 
   @Test
-  public void testValidateNoField() throws Exception {
-    CreateDimensionKey createKey = new CreateDimensionKey();
-    createKey.setName( "field1" );
-    createKey.setDimension( "d" );
-    try {
-      createKey.validate();
-      fail( "no exception" );
-    } catch ( ModelerException e ) {
-      //
-    }
-  }
-
-  @Test
   public void testSummary() throws Exception {
     CreateDimensionKey createKey = new CreateDimensionKey();
     createKey.setName( "name" );
     createKey.setField( "field1" );
     createKey.setDimension( "dim1" );
     LanguageChoice.getInstance().setDefaultLocale( Locale.US );
-    final String summary = createKey.getSummary();
-    assertEquals( "field1 is key for dimension dim1", summary );
+    assertEquals( "field1 is key for dimension dim1", createKey.getSummary() );
+    createKey.setField( null );
+    assertEquals( "name is key for dimension dim1", createKey.getSummary() );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/SharedDimensionGroupCompatibilityTest.java
+++ b/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/SharedDimensionGroupCompatibilityTest.java
@@ -57,7 +57,7 @@ public class SharedDimensionGroupCompatibilityTest {
     SharedDimensionGroup sdg = (SharedDimensionGroup) group;
     assertTrue( sdg.isSharedDimension() );
     assertEquals( 7, sdg.getModelAnnotations().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
     assertEquals( 6, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
     assertEquals( 7, sdg.getModelAnnotations().get( 2 ).describeAnnotation().size() );
     assertEquals( 7, sdg.getModelAnnotations().get( 3 ).describeAnnotation().size() );
@@ -79,7 +79,7 @@ public class SharedDimensionGroupCompatibilityTest {
     assertEquals( 8, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
     assertEquals( 8, sdg.getModelAnnotations().get( 2 ).describeAnnotation().size() );
     assertEquals( 8, sdg.getModelAnnotations().get( 3 ).describeAnnotation().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 4 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 4 ).describeAnnotation().size() );
     assertEquals( 8, sdg.getModelAnnotations().get( 5 ).describeAnnotation().size() );
   }
 
@@ -92,7 +92,7 @@ public class SharedDimensionGroupCompatibilityTest {
     SharedDimensionGroup sdg = (SharedDimensionGroup) group;
     assertTrue( sdg.isSharedDimension() );
     assertEquals( 2, sdg.getModelAnnotations().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
     assertEquals( 6, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
   }
 
@@ -111,7 +111,7 @@ public class SharedDimensionGroupCompatibilityTest {
     assertEquals( 6, sdg.getModelAnnotations().get( 3 ).describeAnnotation().size() );
     assertEquals( 6, sdg.getModelAnnotations().get( 4 ).describeAnnotation().size() );
     assertEquals( 6, sdg.getModelAnnotations().get( 5 ).describeAnnotation().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 6 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 6 ).describeAnnotation().size() );
   }
 
   @Test
@@ -123,7 +123,7 @@ public class SharedDimensionGroupCompatibilityTest {
     SharedDimensionGroup sdg = (SharedDimensionGroup) group;
     assertTrue( sdg.isSharedDimension() );
     assertEquals( 7, sdg.getModelAnnotations().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 2 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 3 ).describeAnnotation().size() );
@@ -141,7 +141,7 @@ public class SharedDimensionGroupCompatibilityTest {
     SharedDimensionGroup sdg = (SharedDimensionGroup) group;
     assertTrue( sdg.isSharedDimension() );
     assertEquals( 2, sdg.getModelAnnotations().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
   }
 
@@ -154,7 +154,7 @@ public class SharedDimensionGroupCompatibilityTest {
     SharedDimensionGroup sdg = (SharedDimensionGroup) group;
     assertTrue( sdg.isSharedDimension() );
     assertEquals( 3, sdg.getModelAnnotations().size() );
-    assertEquals( 2, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
+    assertEquals( 3, sdg.getModelAnnotations().get( 0 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 1 ).describeAnnotation().size() );
     assertEquals( 5, sdg.getModelAnnotations().get( 2 ).describeAnnotation().size() );
   }


### PR DESCRIPTION
…name instead.  6.1 code might have saved the annotation without field.