### PR TITLE
BACKLOG-12127 -- Annotation step incorrectly drops a field when it ha…

### DIFF
--- a/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateMeasure.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateMeasure.java
@@ -240,7 +240,8 @@ public class CreateMeasure extends AnnotationType {
               new MeasureMetaData( targetColumn,
                 getFormatString(),
                 getName(),
-                workspace.getWorkspaceHelper().getLocale() );
+                workspace.getWorkspaceHelper().getLocale(),
+                true );
 
           LogicalColumn columnClone = (LogicalColumn) logicalColumn.clone();
           columnClone.setId( BaseModelerWorkspaceHelper.uniquify( columnClone.getId(), logicalColumns ) );
@@ -327,7 +328,8 @@ public class CreateMeasure extends AnnotationType {
       if ( measureNameEquals( column, measure )
           && measure.getLogicalColumn().getPhysicalColumn().getName( locale ).equals(
           logicalColumn.getPhysicalColumn().getName( locale ) )
-          && measure.getDefaultAggregation().equals( AggregationType.SUM ) ) {
+          && measure.getDefaultAggregation().equals( AggregationType.SUM )
+          && !measure.isManuallyCreated() ) {
         workspace.getModel().getMeasures().remove( measure );
         break;
       }

--- a/core/src/main/java/org/pentaho/agilebi/modeler/nodes/MeasureMetaData.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/nodes/MeasureMetaData.java
@@ -31,6 +31,7 @@ import org.pentaho.ui.xul.stereotype.Bindable;
 public class MeasureMetaData extends BaseAggregationMetaDataNode {
   private static final long serialVersionUID = -7974277299013394857L;
   private static final String IMAGE = "images/sm_measure_icon.png";
+  private boolean manuallyCreated = false;
 
   public MeasureMetaData( String locale ) {
     super( locale );
@@ -38,6 +39,11 @@ public class MeasureMetaData extends BaseAggregationMetaDataNode {
 
   public MeasureMetaData( String fieldName, String format, String displayName, String locale ) {
     super( fieldName, format, displayName, locale );
+  }
+
+  public MeasureMetaData( String fieldName, String format, String displayName, String locale, boolean manual ) {
+    this( fieldName, format, displayName, locale );
+    manuallyCreated = manual;
   }
 
   @Override
@@ -90,4 +96,13 @@ public class MeasureMetaData extends BaseAggregationMetaDataNode {
     }
     return null;
   }
+
+  public boolean isManuallyCreated() {
+    return manuallyCreated;
+  }
+
+  public void setManuallyCreated( boolean manuallyCreated ) {
+    this.manuallyCreated = manuallyCreated;
+  }
+
 }


### PR DESCRIPTION
…s the

same name as a created measure

What was done:
Added field tracking if the measure is autogenerated or explicitly created
Changed th elogic for removing measures.