### PR TITLE
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to P…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-gui-util</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>


### PR DESCRIPTION
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes