### PR TITLE
[SP-3096] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-gui-util</artifactId>
-      <version>1.7</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>


### PR DESCRIPTION
[SP-3096] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (7.0 Suite)