### PR TITLE
Revert "[ANALYZER-2745]-latitude and longitude attributes not being set properly when editing a data model"

### DIFF
--- a/core/src/main/java/org/pentaho/agilebi/modeler/ColResolverController.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/ColResolverController.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.agilebi.modeler;
@@ -88,7 +88,6 @@ public class ColResolverController extends AbstractXulEventHandler {
       return;
     }
     AvailableField field = (AvailableField) selectedFields[0];
-    normalizeFieldName( field );
     ColumnBackedNode cnode = workspace.createColumnBackedNode( field, workspace.getCurrentModelerPerspective() );
     LogicalColumn lCol = cnode.getLogicalColumn();
     if ( ColumnBackedNode.COLUMN_TYPE_SOURCE.equals( columnType ) ) {
@@ -100,11 +99,6 @@ public class ColResolverController extends AbstractXulEventHandler {
     }
     workspace.setDirty( true );
     dialog.hide();
-  }
-
-  private void normalizeFieldName( AvailableField field ) {
-    String fieldName = field.getName().toLowerCase();
-    field.setName( fieldName );
   }
 
   @Bindable

--- a/core/src/main/java/org/pentaho/agilebi/modeler/geo/GeoContextFactory.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/geo/GeoContextFactory.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.agilebi.modeler.geo;
@@ -33,7 +33,10 @@ import java.util.List;
  */
 public class GeoContextFactory {
 
-   /**
+  private static final String LATITUDE = "latitude";
+  private static final String LONGITUDE = "longitude";
+
+  /**
    * This factory method creates a GeoContext from a GeoContextConfigProvider.
    * 
    * @param configProvider
@@ -91,10 +94,10 @@ public class GeoContextFactory {
           + GeoContext.GEO_ROLE_KEY + " property defined." );
     }
 
-    String latAliases = configProvider.getRoleAliases( GeoContext.LATITUDE );
-    LatLngRole latRole = new LatLngRole( GeoContext.LATITUDE, latAliases );
-    String longAliases = configProvider.getRoleAliases( GeoContext.LONGITUDE );
-    LatLngRole longRole = new LatLngRole( GeoContext.LONGITUDE, longAliases );
+    String latAliases = configProvider.getRoleAliases( LATITUDE );
+    LatLngRole latRole = new LatLngRole( LATITUDE, latAliases );
+    String longAliases = configProvider.getRoleAliases( LONGITUDE );
+    LatLngRole longRole = new LatLngRole( LONGITUDE, longAliases );
 
     String displayName = ModelerMessagesHolder.getMessages().getString( "geo.location" );
     if ( StringUtils.isEmpty( displayName ) ) {

--- a/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/ModelingSchemaAnnotatorTest.java
+++ b/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/ModelingSchemaAnnotatorTest.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2017 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2002 - 2016 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -39,7 +39,7 @@ public class ModelingSchemaAnnotatorTest {
     InputStream annotationsInput = getClass().getResourceAsStream( "resources/annotations.xml" );
     InputStream expectedInput = getClass().getResourceAsStream( "resources/annotated.mondrian.xml" );
     InputStream actualInput = annotator.getInputStream( schemaInput, annotationsInput );
-    assertEquals( IOUtils.toString( expectedInput ).replaceAll( "\\r\\n", "\\\n" ), IOUtils.toString( actualInput ).replaceAll( "\\r\\n", "\\\n" ) );
+    assertEquals( IOUtils.toString( expectedInput ), IOUtils.toString( actualInput ) );
   }
 
   @Test


### PR DESCRIPTION
Reverts pentaho/modeler#320

See jira comment: 
http://jira.pentaho.com/browse/ANALYZER-2745?focusedCommentId=290955&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-290955