### PR TITLE
[SP-3405]-[ANALYZER-2745]-latitude and longitude attributes not being set properly when editing a data model

### DIFF
--- a/core/src/main/java/org/pentaho/agilebi/modeler/nodes/LevelMetaData.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/nodes/LevelMetaData.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.agilebi.modeler.nodes;
@@ -229,7 +229,7 @@ public class LevelMetaData extends BaseColumnBackedMetaData<MemberPropertyMetaDa
 
   public MemberPropertyMetaData getLatitudeField() {
     for ( MemberPropertyMetaData member : this ) {
-      if ( member.getName().equals( GeoContext.LATITUDE ) ) {
+      if ( member.getName().equalsIgnoreCase( GeoContext.LATITUDE ) ) {
         return member;
       }
     }
@@ -238,7 +238,7 @@ public class LevelMetaData extends BaseColumnBackedMetaData<MemberPropertyMetaDa
 
   public MemberPropertyMetaData getLongitudeField() {
     for ( MemberPropertyMetaData member : this ) {
-      if ( member.getName().equals( GeoContext.LONGITUDE ) ) {
+      if ( member.getName().equalsIgnoreCase( GeoContext.LONGITUDE ) ) {
         return member;
       }
     }

--- a/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/ModelingSchemaAnnotatorTest.java
+++ b/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/ModelingSchemaAnnotatorTest.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2016 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2002 - 2017 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -39,7 +39,8 @@ public class ModelingSchemaAnnotatorTest {
     InputStream annotationsInput = getClass().getResourceAsStream( "resources/annotations.xml" );
     InputStream expectedInput = getClass().getResourceAsStream( "resources/annotated.mondrian.xml" );
     InputStream actualInput = annotator.getInputStream( schemaInput, annotationsInput );
-    assertEquals( IOUtils.toString( expectedInput ), IOUtils.toString( actualInput ) );
+    assertEquals( IOUtils.toString( expectedInput ).replaceAll( "\\r\\n", "\\\n" ), IOUtils.toString( actualInput )
+            .replaceAll( "\\r\\n", "\\\n" ) );
   }
 
   @Test


### PR DESCRIPTION
Corrected check for a lat/long field name
Fixed failing test