### PR TITLE
[BACKLOG-15562] Removed duplicate levels from the same hierarchy

### DIFF
--- a/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateAttribute.java
+++ b/core/src/main/java/org/pentaho/agilebi/modeler/models/annotations/CreateAttribute.java
@@ -596,6 +596,7 @@ public class CreateAttribute extends AnnotationType {
       LevelMetaData levelMetaData = new LevelMetaData( existingHierarchy, getName() );
       existingHierarchy.add( parentIndex + 1, levelMetaData );
       fillLevelProperties( workspace, logicalColumn, levelMetaData );
+      removeDuplicateLevel( levelMetaData );
       removeAutoLevel( workspace, existingLevel );
       removeAutoMeasure( workspace, column );
       removeAutoLevel( workspace, ordinalAutoLevel );
@@ -742,5 +743,20 @@ public class CreateAttribute extends AnnotationType {
 
     return eq.isEquals();
 
+  }
+
+  protected void removeDuplicateLevel( final LevelMetaData levelMetaData ) {
+    if ( null == levelMetaData || null == levelMetaData.getHierarchyMetaData() ) {
+      return;
+    }
+
+    HierarchyMetaData hierarchyMetaData = levelMetaData.getHierarchyMetaData();
+
+    for ( LevelMetaData duplicateLevel : hierarchyMetaData.getLevels() ) {
+      if ( levelMetaData.getName().equals( duplicateLevel.getName() ) && duplicateLevel != levelMetaData ) {
+        hierarchyMetaData.remove( duplicateLevel );
+        break;
+      }
+    }
   }
 }

--- a/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/CreateAttributeTest.java
+++ b/core/src/test/java/org/pentaho/agilebi/modeler/models/annotations/CreateAttributeTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -21,8 +21,14 @@
 package org.pentaho.agilebi.modeler.models.annotations;
 
 import org.junit.Test;
+import org.pentaho.agilebi.modeler.nodes.HierarchyMetaData;
+import org.pentaho.agilebi.modeler.nodes.LevelMetaData;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by rfellows on 6/8/16.
@@ -98,5 +104,29 @@ public class CreateAttributeTest {
     assertTrue( left.equalsLogically( right ) );
   }
 
+  @Test
+  public void testRemovingDuplicateLevels() {
+    LevelMetaData duplicateLevel = new LevelMetaData();
+    duplicateLevel.setName( "testLevel" );
+    LevelMetaData notDuplicateLevel = new LevelMetaData();
+    notDuplicateLevel.setName( "notDuplicateLevel" );
 
+    HierarchyMetaData existingHierarchy = mock( HierarchyMetaData.class );
+
+    LevelMetaData newLevel = new LevelMetaData( existingHierarchy, "testLevel" );
+
+    when( existingHierarchy.getLevels() ).thenReturn( new ArrayList<>( Arrays.asList( duplicateLevel, notDuplicateLevel, newLevel ) ) );
+
+    CreateAttribute createAttribute = new CreateAttribute();
+    createAttribute.removeDuplicateLevel( newLevel );
+
+    // Ensure duplicate level was removed
+    verify( existingHierarchy ).remove( duplicateLevel );
+
+    // Test not being a duplicate so level should not be removed
+    reset( existingHierarchy );
+    duplicateLevel.setName( "alsoNotDuplicate" );
+    createAttribute.removeDuplicateLevel( newLevel );
+    verify( existingHierarchy, never() ).remove( duplicateLevel );
+  }
 }


### PR DESCRIPTION
Having levels with the same name in the same hierarchy was causing
errors in DET. This can also cause confusion for the user. The
approach now is to only allow the last level annotation with the
duplicate name to exist on the hierarachy.