### PR TITLE
BACKLOG-19759 - Fixed Integration tests for Modeler

### DIFF
--- a/core/src/it/java/org/pentaho/agilebi/modeler/ModelsDnDIT.java
+++ b/core/src/it/java/org/pentaho/agilebi/modeler/ModelsDnDIT.java
@@ -210,144 +210,53 @@ public class ModelsDnDIT extends AbstractModelerTest {
     MeasureMetaData secondMeasure = measures.get( 1 );
 
     // top-down drops are invalid, only bottom up
-    try {
-      assertNull( firstHier.onDrop( firstDim ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstLevel.onDrop( firstDim ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstLevel.onDrop( firstHier ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( dimensions.onDrop( workspace.getModel() ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
+    assertNull( firstHier.onDrop( firstDim ) );
+
+    assertNull( firstLevel.onDrop( firstDim ) );
+
+    assertNull( firstLevel.onDrop( firstHier ) );
+
+    assertNull( dimensions.onDrop( workspace.getModel() ) );
 
     // cannot drag dimensions and measures collections not the mainModelNode anywhere
-    try {
-      assertNull( dimensions.onDrop( measures ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( mainNode.onDrop( measures ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstDim.onDrop( measures ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstHier.onDrop( measures ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstLevel.onDrop( measures ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
+    assertNull( dimensions.onDrop( measures ) );
 
-    try {
-      assertNull( measures.onDrop( dimensions ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( mainNode.onDrop( dimensions ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstDim.onDrop( dimensions ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstHier.onDrop( dimensions ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstLevel.onDrop( dimensions ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
+    assertNull( mainNode.onDrop( measures ) );
 
-    try {
-      assertNull( measures.onDrop( mainNode ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( dimensions.onDrop( mainNode ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstDim.onDrop( mainNode ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstHier.onDrop( mainNode ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstLevel.onDrop( mainNode ) );
-      fail( "Should have thrown an exception" );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
+    assertNull( firstDim.onDrop( measures ) );
+
+    assertNull( firstHier.onDrop( measures ) );
+
+    assertNull( firstLevel.onDrop( measures ) );
+
+    assertNull( measures.onDrop( dimensions ) );
+
+    assertNull( mainNode.onDrop( dimensions ) );
+
+    assertNull( firstDim.onDrop( dimensions ) );
+
+    assertNull( firstHier.onDrop( dimensions ) );
+
+    assertNull( firstLevel.onDrop( dimensions ) );
+
+    assertNull( measures.onDrop( mainNode ) );
+
+    assertNull( dimensions.onDrop( mainNode ) );
+
+    assertNull( firstDim.onDrop( mainNode ) );
+
+    assertNull( firstHier.onDrop( mainNode ) );
+
+    assertNull( firstLevel.onDrop( mainNode ) );
 
     // same type of node onto another... universally bad
-    try {
-      assertNull( firstLevel.onDrop( secondLevel ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstHier.onDrop( secondHier ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstDim.onDrop( secondDim ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
-    try {
-      assertNull( firstMeasure.onDrop( secondMeasure ) );
-    } catch ( ModelerException e ) {
-      // ignore
-    }
+    assertNull( firstLevel.onDrop( secondLevel ) );
+
+    assertNull( firstHier.onDrop( secondHier ) );
+
+    assertNull( firstDim.onDrop( secondDim ) );
+
+    assertNull( firstMeasure.onDrop( secondMeasure ) );
 
   }
 

--- a/core/src/it/java/org/pentaho/agilebi/modeler/models/annotations/LinkDimensionIT.java
+++ b/core/src/it/java/org/pentaho/agilebi/modeler/models/annotations/LinkDimensionIT.java
@@ -132,7 +132,7 @@ public class LinkDimensionIT {
     assertEquals( 4, dimensionUsages.size() );
     OlapDimensionUsage productDim = dimensionUsages.get( 3 );
     OlapHierarchy productHierarchy = productDim.getOlapDimension().getHierarchies().get( 0 );
-    assertEquals( "PRODUCT", productHierarchy.getLogicalTable().getName( "en_us" ) );
+    assertEquals( "product", productHierarchy.getLogicalTable().getName( "en_us" ) );
 
     OlapHierarchyLevel nameLevel = productHierarchy.getHierarchyLevels().get( 0 );
     assertEquals( "Product", nameLevel.getName() );
@@ -283,7 +283,7 @@ public class LinkDimensionIT {
     assertEquals( 5, dimensionUsages.size() );
     OlapDimensionUsage productDim = dimensionUsages.get( 3 );
     OlapHierarchy productHierarchy = productDim.getOlapDimension().getHierarchies().get( 0 );
-    assertEquals( "PRODUCT", productHierarchy.getLogicalTable().getName( "en_us" ) );
+    assertEquals( "product", productHierarchy.getLogicalTable().getName( "en_us" ) );
 
     OlapHierarchyLevel nameLevel = productHierarchy.getHierarchyLevels().get( 0 );
     assertEquals( "Product", nameLevel.getName() );
@@ -292,7 +292,7 @@ public class LinkDimensionIT {
 
     OlapDimensionUsage descriptionDim = dimensionUsages.get( 4 );
     OlapHierarchy descriptionHierarchy = descriptionDim.getOlapDimension().getHierarchies().get( 0 );
-    assertEquals( "PRODUCT", productHierarchy.getLogicalTable().getName( "en_us" ) );
+    assertEquals( "product", productHierarchy.getLogicalTable().getName( "en_us" ) );
     OlapHierarchyLevel descriptionLevel = descriptionHierarchy.getHierarchyLevels().get( 0 );
     assertEquals( "Description", descriptionLevel.getName() );
     assertEquals( "PRODUCT DESCRIPTION",
@@ -373,7 +373,7 @@ public class LinkDimensionIT {
 
     assertEquals( 1, dateDim.getOlapDimension().getHierarchies().size() );
     OlapHierarchy dateHierarchy = dateDim.getOlapDimension().getHierarchies().get( 0 );
-    assertEquals( "MYDATE", dateHierarchy.getLogicalTable().getName( "en_us" ) );
+    assertEquals( "mydate", dateHierarchy.getLogicalTable().getName( "en_us" ) );
     assertEquals( "Date", dateHierarchy.getName() );
 
     OlapHierarchyLevel yearLevel = dateHierarchy.getHierarchyLevels().get( 0 );


### PR DESCRIPTION
@rmansoor @tkafalas please take a look

NOTE:
The changes to fix test ModelsDnDIT.java were made to address the changes in this commit:  https://github.com/pentaho/modeler/commit/ad0d38a2ae90b8272bcc035c89e6722167419d66

That commit made a lot of the "drop" condition checking return "null" instead of throwing errors.  So the fix for ModelsDnDIT.java was to expect null values instead of exceptions in the negative test scenario.