### PR TITLE
[PPP-4495] Use of Vulnerable Component: Components/legion-of-the-boun…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
       <artifactId>bcmail-jdk14</artifactId>
       <version>138</version>
     </dependency>
-    <dependency>
-      <groupId>bouncycastle</groupId>
-      <artifactId>bcprov-jdk14</artifactId>
-      <version>138</version>
-    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
…cy-castle-java-crytography-api

- Removing unused dependency
- This is a transitive of `org.pentaho.reporting.engine:classic-core` 

Related PRs:
1. https://github.com/pentaho/modeler/pull/365 (this one)
2. https://github.com/pentaho/pentaho-kettle/pull/7450
3. https://github.com/pentaho/pentaho-platform/pull/4689
4. https://github.com/pentaho/pentaho-reporting/pull/1347
5. https://github.com/pentaho/big-data-plugin/pull/2059
6. https://github.com/pentaho/pentaho-big-data-ee/pull/447
7. https://github.com/pentaho/pentaho-karaf-assembly/pull/640