### PR TITLE
[BACKLOG-42737]-Upgrading modeler from Java EE to Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-servlet</artifactId>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-servlet-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
@@ -172,9 +172,9 @@
       <version>${mondrian.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.1</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
[BACKLOG-42737]-Upgrading modeler from Java EE to Jakarta EE

[BACKLOG-42737]: https://hv-eng.atlassian.net/browse/BACKLOG-42737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ