### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-servlet</artifactId>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-servlet-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>


### PR DESCRIPTION
This pull request updates dependencies in the `pom.xml` file to modernize the project and remove outdated libraries. The most important changes include replacing `gwt-servlet` with `gwt-servlet-jakarta` and removing multiple dependencies related to Jersey.

Dependency updates:

* Replaced the `gwt-servlet` dependency with `gwt-servlet-jakarta` to align with updated group and artifact IDs (`org.gwtproject:gwt-servlet-jakarta`).

Dependency removals:

* Removed several outdated Jersey dependencies, including `jersey-core`, `jersey-bundle`, `jersey-client`, and `jersey-apache-client` (all version `1.16`), to streamline the dependency list and reduce reliance on legacy libraries.