### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
         <executions>
           <execution>
             <goals>

--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -35,7 +35,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>${gwt.version}</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,11 @@
       <artifactId>gwt-dnd</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>
@@ -219,9 +219,9 @@
       <version>20100529</version>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>3.2</version>
+      <version>9.6</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `pom.xml` files to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, and `gwt-dev` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization.
* Update `asm` version to the one compatible with current version of `gwt` and `JDK 17`.

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.