### PR TITLE
build[PPP-6390][PPP-6391]: update Bouncy Castle dependency version variable in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
+      <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file by updating the bouncycastle version property to `bouncycastle.version`, as to use the new one declared in maven-parent-poms: https://github.com/pentaho/maven-parent-poms/pull/843