### PR TITLE
build[SP-7277]: update Bouncy Castle dependency version variable in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
+      <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/modeler/pull/407

## Changes
- Cherry-picked from https://github.com/pentaho/modeler/pull/407
- Commit: 3e14507cee53a46b0296acb0c7191c0f774511a4

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
